### PR TITLE
feat: derive display dates from filename; date/time-aware permalinks and sorting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,10 +9,10 @@ plugins:
 collections:
   longform:
     output: true
-    permalink: /tales/:title/
+    permalink: /tales/:path/
   shortform:
     output: true
-    permalink: /notes/:title/
+    permalink: /notes/:path/
 feed:
   collections:
   - longform

--- a/_includes/date.html
+++ b/_includes/date.html
@@ -1,0 +1,34 @@
+{%- comment -%}
+Outputs a human date for a doc, preferring front matter `date:`.
+If missing, derive from filename: YYYY-MM-DD[-HHMM]-slug.md.
+Usage: {% include date.html doc=entry format="%b %-d, %Y" %}
+{%- endcomment -%}
+
+{%- assign d = include.doc.date -%}
+{%- if d == nil or d == empty -%}
+  {%- assign fname = include.doc.name | replace: '.markdown','' | replace: '.md','' -%}
+  {%- assign parts = fname | split: '-' -%}
+  {%- if parts.size >= 3 -%}
+    {%- assign yyyy = parts[0] -%}
+    {%- assign mm   = parts[1] -%}
+    {%- assign dd   = parts[2] -%}
+    {%- comment -%} Optional HHMM in 4th segment {%- endcomment -%}
+    {%- assign hhmm = parts[3] -%}
+    {%- assign hhmm_digits = hhmm | remove:'0' | remove:'1' | remove:'2' | remove:'3' | remove:'4' | remove:'5' | remove:'6' | remove:'7' | remove:'8' | remove:'9' -%}
+    {%- if hhmm and hhmm.size == 4 and hhmm_digits == '' -%}
+      {%- assign hh = hhmm | slice: 0, 2 -%}
+      {%- assign mi = hhmm | slice: 2, 2 -%}
+      {%- assign datestr = yyyy | append: '-' | append: mm | append: '-' | append: dd | append: ' ' | append: hh | append: ':' | append: mi -%}
+    {%- else -%}
+      {%- assign datestr = yyyy | append: '-' | append: mm | append: '-' | append: dd -%}
+    {%- endif -%}
+    {%- assign d = datestr -%}
+  {%- endif -%}
+{%- endif -%}
+
+{%- if d -%}
+  {{ d | date: include.format | default: "%b %-d, %Y" }}
+{%- else -%}
+  Undated
+{%- endif -%}
+

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,10 +4,13 @@
     <img src="{{ site.baseurl }}/assets/img/the_interurbanist_flag_1411x294.jpg" alt="The Interurbanist flag" class="brand-flag">
     <div class="brand-text">
       <h1 class="site-title">{{ site.title }}</h1>
-      {% assign all = site.longform | concat: site.shortform | sort: 'date' | reverse %}
+      {% assign all = site.longform | concat: site.shortform | sort: 'path' | reverse %}
       {% assign latest = all | first %}
-      <p class="site-desc">{{ site.description }} | Most recent post:
-        {% if latest and latest.date %}{{ latest.date | date: "%b %-d" }}{% else %}n/a{% endif %}.
+      <p class="site-desc">
+        {{ site.description }} | Most recent post:
+        {% if latest %}
+          {% include date.html doc=latest format="%b %-d" %}
+        {% else %}n/a{% endif %}.
       </p>
     </div>
   </div>

--- a/_layouts/entry.html
+++ b/_layouts/entry.html
@@ -6,7 +6,8 @@ layout: default
     <h1 class="entry-title">{{ page.title }}</h1>
     <div class="meta">
       <time datetime="{{ page.date | date_to_xmlschema }}">
-        {% if page.date %}{{ page.date | date: "%b %-d, %Y" }}{% else %}Undated{% endif %}
+        {% capture fmt %}{% if page.section == 'notes' %}%b %-d, %Y • %l:%M %P{% else %}%b %-d, %Y{% endif %}{% endcapture %}
+        {% include date.html doc=page format=fmt %}
       </time>
       {% if page.author %} · <span class="author">{{ page.author }}</span>{% endif %}
       {% if page.type %} · <span class="type">{{ page.type }}</span>{% endif %}

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ title: Home
 
 <section id="timeline" class="timeline-view" aria-label="All items in chronological order">
   <h2 class="visually-hidden">Timeline</h2>
-  {% assign all = site.longform | concat: site.shortform | sort: 'date' | reverse %}
+  {% assign all = site.longform | concat: site.shortform | sort: 'path' | reverse %}
   <ul class="timeline-list">
   {% for entry in all %}
     {% assign expired = false %}
@@ -23,8 +23,9 @@ title: Home
         </div>
         <div class="card-body">
           <h3 class="card-title">{{ entry.title }}</h3>
-          <p class="card-meta"><time datetime="{{ entry.date | date_to_xmlschema }}">
-            {% if entry.date %}{{ entry.date | date: "%b %-d, %Y" }}{% else %}Undated{% endif %}
+          <p class="card-meta"><time>
+            {% capture fmt %}{% if entry.section == 'notes' %}%b %-d, %Y • %l:%M %P{% else %}%b %-d, %Y{% endif %}{% endcapture %}
+            {% include date.html doc=entry format=fmt %}
           </time>{% if entry.type %} · {{ entry.type }}{% endif %}</p>
           {% if entry.summary %}<p class="card-summary">{{ entry.summary }}</p>{% endif %}
         </div>
@@ -43,7 +44,7 @@ title: Home
         <header class="col-header"><h3>{{ s.label }}</h3></header>
         <ul class="col-list">
           {% if s.collection == "longform" %}
-            {% assign list = site.longform | sort: 'date' | reverse %}
+            {% assign list = site.longform | sort: 'path' | reverse %}
           {% else %}
             {% assign list = site.shortform %}
             {% if s.filter_field and s.filter_value %}
@@ -52,7 +53,7 @@ title: Home
             {% if s.sort == "starts_at" %}
               {% assign list = list | sort: 'starts_at' %}
             {% else %}
-              {% assign list = list | sort: 'date' | reverse %}
+              {% assign list = list | sort: 'path' | reverse %}
             {% endif %}
           {% endif %}
           {% for entry in list %}
@@ -71,8 +72,9 @@ title: Home
                 <div class="card-body">
                   <h4 class="card-title">{{ entry.title }}</h4>
                   <p class="card-meta">
-                    <time datetime="{{ entry.date | date_to_xmlschema }}">
-                      {% if entry.date %}{{ entry.date | date: "%b %-d, %Y" }}{% else %}Undated{% endif %}
+                    <time>
+                      {% capture fmt %}{% if entry.section == 'notes' %}%b %-d, %Y • %l:%M %P{% else %}%b %-d, %Y{% endif %}{% endcapture %}
+                      {% include date.html doc=entry format=fmt %}
                     </time>
                     {% if entry.type %} · {{ entry.type }}{% endif %}
                   </p>


### PR DESCRIPTION
## Summary
- derive visible post dates from front matter or filename
- use path-based permalinks and sorting for content collections
- show recent post date and card dates via new `date.html` helper

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af646d4b208333a7089bdf8f57b1ec