### PR TITLE
Link flag image to site root

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,9 @@
 <header class="site-header">
   <a class="skip" href="#content">Skip to content</a>
   <div class="brand">
-    <img src="{{ site.baseurl }}/assets/img/the_interurbanist_flag_1411x294.jpg" alt="The Interurbanist flag" class="brand-flag">
+    <a href="{{ site.baseurl }}/">
+      <img src="{{ site.baseurl }}/assets/img/the_interurbanist_flag_1411x294.jpg" alt="The Interurbanist flag" class="brand-flag">
+    </a>
     <div class="brand-text">
       <h1 class="site-title">{{ site.title }}</h1>
       {% assign all = site.longform | concat: site.shortform | sort: 'path' | reverse %}


### PR DESCRIPTION
## Summary
- Wrap the header flag image in a link to the site's root for easy navigation

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68af6c40d3608333a18dc687fc76059e