### PR TITLE
Refactor section metadata and media helpers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,13 +24,40 @@ defaults:
 
 # Canonical section definitions (single source of truth)
 sections:
-  - { slug: tales,       label: "Tales from the Independent" }
-  - { slug: events,      label: "Events Notice" }
-  - { slug: management,  label: "From the Management" }
-  - { slug: lostnfound,  label: "Lost & Found" }
-  - { slug: safety,      label: "Safety Tips for Long Lives" }
-  - { slug: style,       label: "Style & Grace" }
-  - { slug: visions,     label: "Visions of Independent Living" }
+  - slug: tales
+    label: "Tales from the Independent"
+  - slug: events
+    label: "Events Notice"
+    sort:
+      key: starts_at
+      direction: asc
+    card:
+      date_format: "%b %-d, %Y • %l:%M %P"
+      date_field: starts_at
+      default_format: "%b %-d, %Y"
+      show_location: true
+    entry:
+      date_format: "%b %-d, %Y • %l:%M %P"
+      date_field: starts_at
+  - slug: management
+    label: "From the Management"
+  - slug: lostnfound
+    label: "Lost & Found"
+  - slug: safety
+    label: "Safety Tips for Long Lives"
+  - slug: style
+    label: "Style & Grace"
+  - slug: visions
+    label: "Visions of Independent Living"
+    entry:
+      date_format: "%b %-d, %Y • %l:%M %P"
+
+placeholders:
+  card: /assets/placeholders/placeholder_card_400x300.png
+
+date_formats:
+  card_default: "%b %-d, %Y"
+  entry_default: "%b %-d, %Y"
 
 exclude:
   - _local

--- a/_includes/card_media.html
+++ b/_includes/card_media.html
@@ -1,0 +1,16 @@
+{%- assign wrapper_class = include.wrapper_class | default: 'card-media' -%}
+{%- assign placeholder = include.placeholder | default: site.placeholders.card | default: '/assets/placeholders/placeholder_card_400x300.png' -%}
+{%- assign image = include.image -%}
+<div class="{{ wrapper_class }}">
+  {%- if image -%}
+    {%- capture resolved -%}{% include media_url.html src=image.src item=include.item base=include.base prefix=include.prefix %}{%- endcapture -%}
+    {%- assign resolved = resolved | strip -%}
+    {%- if resolved != '' -%}
+      <img src="{{ resolved | relative_url }}" alt="{{ image.alt | default: include.alt | default: '' }}">
+    {%- else -%}
+      <img src="{{ placeholder | relative_url }}" alt="">
+    {%- endif -%}
+  {%- else -%}
+    <img src="{{ placeholder | relative_url }}" alt="">
+  {%- endif -%}
+</div>

--- a/_includes/media_url.html
+++ b/_includes/media_url.html
@@ -1,0 +1,24 @@
+{%- assign raw = include.src | to_s | strip -%}
+{%- assign resolved = '' -%}
+{%- if raw != '' -%}
+  {%- if raw contains '://' -%}
+    {%- assign resolved = raw -%}
+  {%- else -%}
+    {%- assign first = raw | slice: 0, 1 -%}
+    {%- assign cleaned = raw | replace: './', '' -%}
+    {%- if first == '/' -%}
+      {%- assign resolved = raw -%}
+    {%- else -%}
+      {%- assign base_path = include.base | default: '' -%}
+      {%- if base_path == '' and include.item -%}
+        {%- assign item = include.item -%}
+        {%- if item.path and item.name -%}
+          {%- assign base_path = item.path | replace: item.name, '' -%}
+        {%- endif -%}
+      {%- endif -%}
+      {%- assign prefix = include.prefix | default: '/' -%}
+      {%- assign resolved = prefix | append: base_path | append: cleaned -%}
+    {%- endif -%}
+  {%- endif -%}
+{%- endif -%}
+{{ resolved | strip }}

--- a/_includes/resolve_date_format.html
+++ b/_includes/resolve_date_format.html
@@ -1,0 +1,32 @@
+{%- assign default_format = include.default | default: "%b %-d, %Y" -%}
+{%- assign selected_format = default_format -%}
+{%- assign settings = include.settings -%}
+{%- if settings -%}
+  {%- if settings.default_format -%}
+    {%- assign selected_format = settings.default_format -%}
+  {%- endif -%}
+  {%- if settings.date_format -%}
+    {%- assign use_custom = true -%}
+    {%- if settings.date_field -%}
+      {%- assign field_name = settings.date_field -%}
+      {%- assign doc = include.doc -%}
+      {%- if doc -%}
+        {%- assign field_value = doc[field_name] -%}
+        {%- if field_value == nil -%}
+          {%- assign use_custom = false -%}
+        {%- else -%}
+          {%- assign field_string = field_value | to_s | strip -%}
+          {%- if field_string == '' -%}
+            {%- assign use_custom = false -%}
+          {%- endif -%}
+        {%- endif -%}
+      {%- else -%}
+        {%- assign use_custom = false -%}
+      {%- endif -%}
+    {%- endif -%}
+    {%- if use_custom -%}
+      {%- assign selected_format = settings.date_format -%}
+    {%- endif -%}
+  {%- endif -%}
+{%- endif -%}
+{{ selected_format | strip }}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,20 +6,21 @@
 {%- comment -%} Resolve an image for OG/Twitter without using filters in comparisons {%- endcomment -%}
 {%- assign base = site.baseurl | default: '' -%}
 
-{%- assign _src = '' -%}
+{%- assign og_source = '' -%}
 {%- if page.images and page.images.size > 0 and page.images[0].src -%}
-  {%- assign _src = page.images[0].src | to_s -%}
-{%- elsif site.logo -%}
-  {%- assign _src = site.logo | to_s -%}
+  {%- capture og_candidate -%}{% include media_url.html src=page.images[0].src item=page %}{%- endcapture -%}
+  {%- assign og_source = og_candidate | strip -%}
+{%- endif -%}
+{%- if og_source == '' and site.logo -%}
+  {%- assign og_source = site.logo | to_s | strip -%}
 {%- endif -%}
 
 {%- assign og_image = '' -%}
-{%- if _src != '' -%}
-  {%- assign first_char = _src | slice: 0, 1 -%}
-  {%- if first_char == '/' -%}
-    {%- assign og_image = _src -%}
+{%- if og_source != '' -%}
+  {%- if og_source contains '://' -%}
+    {%- assign og_image = og_source -%}
   {%- else -%}
-    {%- assign cleaned = _src | replace: './', '' -%}
+    {%- assign cleaned = og_source | replace: './', '' -%}
     {%- assign og_image = '/' | append: base | append: '/' | append: cleaned -%}
     {%- assign og_image = og_image | replace: '//', '/' -%}
   {%- endif -%}

--- a/_layouts/entry.html
+++ b/_layouts/entry.html
@@ -1,6 +1,17 @@
 ---
 layout: default
 ---
+{%- assign default_entry_format = site.date_formats.entry_default | default: "%b %-d, %Y" -%}
+{%- assign page_section_slug = page.section | to_s | strip | downcase -%}
+{%- assign page_section = site.sections | where:"slug", page_section_slug | first -%}
+{%- if page_section == blank -%}
+  {%- assign page_section = site.sections[page_section_slug] -%}
+{%- endif -%}
+{%- assign page_entry_settings = nil -%}
+{%- if page_section and page_section.entry -%}
+  {%- assign page_entry_settings = page_section.entry -%}
+{%- endif -%}
+{%- capture page_entry_format -%}{% include resolve_date_format.html settings=page_entry_settings doc=page default=default_entry_format %}{%- endcapture -%}
 <article class="entry" itemscope itemtype="https://schema.org/Article">
   <header class="entry-header">
     <h1 class="entry-title" itemprop="headline">{{ page.title }}</h1>
@@ -8,8 +19,7 @@ layout: default
       <time
         datetime="{% include date.html doc=page format='%Y-%m-%dT%H:%M:00%z' %}"
         itemprop="datePublished">
-        {% capture human %}{% if page.section == 'visions' %}%b %-d, %Y • %l:%M %P{% else %}%b %-d, %Y{% endif %}{% endcapture %}
-        {% include date.html doc=page format=human %}
+        {% include date.html doc=page format=page_entry_format %}
       </time>
       {% if page.author %} · <span class="author" itemprop="author">{{ page.author }}</span>{% endif %}
       {% if page.type %} · <span class="type">{{ page.type }}</span>{% endif %}
@@ -26,18 +36,11 @@ layout: default
     <section class="gallery" aria-label="Image gallery" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
       <div class="gallery-strip">
         {% for img in page.images %}
-          {% assign _src = img.src %}
-          {% assign first = _src | slice: 0, 1 %}
-          {% assign cleaned = _src | replace: './', '' %}
-
-          {% if _src contains '://' %}
-            {% assign resolved = _src %}
-          {% elsif first == '/' %}
-            {% assign resolved = _src %}
-          {% else %}
-            {% assign base = page.path | replace: page.name, '' %}
-            {% assign resolved = '/' | append: base | append: cleaned %}
-          {% endif %}
+          {%- capture resolved -%}{% include media_url.html src=img.src item=page %}{%- endcapture -%}
+          {%- assign resolved = resolved | strip -%}
+          {%- if resolved == '' -%}
+            {%- assign resolved = img.src | to_s | strip -%}
+          {%- endif -%}
 
           <a href="{{ resolved | relative_url }}" class="lb" data-group="fm">
             <img src="{{ resolved | relative_url }}" alt="{{ img.alt | default: '' }}">
@@ -51,18 +54,11 @@ layout: default
     </section>
 
   {% elsif page.images and page.images.size == 1 %}
-    {% assign _src = page.images[0].src %}
-    {% assign first = _src | slice: 0, 1 %}
-    {% assign cleaned = _src | replace: './', '' %}
-
-    {% if _src contains '://' %}
-      {% assign resolved = _src %}
-    {% elsif first == '/' %}
-      {% assign resolved = _src %}
-    {% else %}
-      {% assign base = page.path | replace: page.name, '' %}
-      {% assign resolved = '/' | append: base | append: cleaned %}
-    {% endif %}
+    {%- capture resolved -%}{% include media_url.html src=page.images[0].src item=page %}{%- endcapture -%}
+    {%- assign resolved = resolved | strip -%}
+    {%- if resolved == '' -%}
+      {%- assign resolved = page.images[0].src | to_s | strip -%}
+    {%- endif -%}
 
     <figure class="hero" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
       <a href="{{ resolved | relative_url }}" class="lb" data-group="single">

--- a/index.html
+++ b/index.html
@@ -5,39 +5,40 @@ title: Home
 
 <div class="sections-view">
   {% assign tales = site.pages | where_exp:"p","p.url contains '/tales/'" %}
+  {% assign default_card_format = site.date_formats.card_default | default: "%b %-d, %Y" %}
+  {% assign default_entry_format = site.date_formats.entry_default | default: "%b %-d, %Y" %}
+  {% assign tales_section = site.sections | where: "slug", "tales" | first %}
+  {% assign tales_sort_key = 'path' %}
+  {% assign tales_sort_direction = 'desc' %}
+  {% if tales_section and tales_section.sort %}
+    {% if tales_section.sort.key %}{% assign tales_sort_key = tales_section.sort.key %}{% endif %}
+    {% if tales_section.sort.direction %}{% assign tales_sort_direction = tales_section.sort.direction %}{% endif %}
+  {% endif %}
+  {% assign tales_list = tales | sort: tales_sort_key %}
+  {% assign tales_direction = tales_sort_direction | to_s | downcase | strip %}
+  {% if tales_direction == 'desc' %}
+    {% assign tales_list = tales_list | reverse %}
+  {% endif %}
+  {% assign tales_card_settings = nil %}
+  {% if tales_section and tales_section.card %}
+    {% assign tales_card_settings = tales_section.card %}
+  {% endif %}
 
   <div class="grid">
     <!-- Tales / longform (preserved) -->
     <section class="col">
       <header class="col-header"><h2>📝 Tales from the Independent</h2></header>
       <ul class="col-list">
-        {% assign list = tales | sort: 'path' | reverse %}
-        {% for entry in list limit: 20 %}
+        {% for entry in tales_list limit: 20 %}
           <li>
             <a class="card" href="{{ entry.url | relative_url }}">
               {% assign hero = entry.images | first %}
-              <div class="card-media">
-                {% if hero %}
-                  {% assign _src = hero.src %}
-                  {% assign first = _src | slice: 0, 1 %}
-                  {% assign cleaned = _src | replace: './', '' %}
-                  {% if _src contains '://' %}
-                    {% assign resolved = _src %}
-                  {% elsif first == '/' %}
-                    {% assign resolved = _src %}
-                  {% else %}
-                    {% assign base = entry.path | replace: entry.name, '' %}
-                    {% assign resolved = '/' | append: base | append: cleaned %}
-                  {% endif %}
-                  <img src="{{ resolved | relative_url }}" alt="{{ hero.alt | default: '' }}">
-                {% else %}
-                  <img src="{{ '/assets/placeholders/placeholder_card_400x300.png' | relative_url }}" alt="">
-                {% endif %}
-              </div>
+              {% include card_media.html image=hero item=entry %}
               <div class="card-body">
                 <h3 class="card-title">{{ entry.title }}</h3>
                 <p class="card-meta">
-                  <time>{% include date.html doc=entry format="%b %-d, %Y" %}</time>
+                  {% capture card_fmt -%}{% include resolve_date_format.html settings=tales_card_settings doc=entry default=default_card_format %}{%- endcapture %}
+                  <time>{% include date.html doc=entry format=card_fmt %}</time>
                 </p>
                 {% if entry.summary %}<p class="card-summary">{{ entry.summary }}</p>{% endif %}
               </div>
@@ -58,11 +59,18 @@ title: Home
       {% assign slug  = s.slug %}
 
       {% assign collection = site.pages | where: "section", slug %}
-      {% if slug == 'events' %}
-        {% assign list = collection | sort: 'starts_at' %}
-      {% else %}
-        {% assign list = collection | sort: 'path' | reverse %}
+      {% assign sort_key = 'path' %}
+      {% assign sort_direction = 'desc' %}
+      {% if s.sort %}
+        {% if s.sort.key %}{% assign sort_key = s.sort.key %}{% endif %}
+        {% if s.sort.direction %}{% assign sort_direction = s.sort.direction %}{% endif %}
       {% endif %}
+      {% assign list = collection | sort: sort_key %}
+      {% assign normalized_direction = sort_direction | to_s | downcase | strip %}
+      {% if normalized_direction == 'desc' %}
+        {% assign list = list | reverse %}
+      {% endif %}
+      {% assign card_settings = s.card %}
 
       <section class="col">
         <header class="col-header"><h2>{{ label }}</h2></header>
@@ -71,38 +79,13 @@ title: Home
             <li>
               <a class="card card-compact" href="{{ entry.url | relative_url }}">
                 {% assign hero = entry.images | first %}
-                <div class="card-media">
-                  {% if hero %}
-                    {% assign _src = hero.src %}
-                    {% assign first = _src | slice: 0, 1 %}
-                    {% assign cleaned = _src | replace: './', '' %}
-                    {% if _src contains '://' %}
-                      {% assign resolved = _src %}
-                    {% elsif first == '/' %}
-                      {% assign resolved = _src %}
-                    {% else %}
-                      {% assign base = entry.path | replace: entry.name, '' %}
-                      {% assign resolved = '/' | append: base | append: cleaned %}
-                    {% endif %}
-                    <img src="{{ resolved | relative_url }}" alt="{{ hero.alt | default: '' }}">
-                  {% else %}
-                    <img src="{{ '/assets/placeholders/placeholder_card_400x300.png' | relative_url }}" alt="">
-                  {% endif %}
-                </div>
+                {% include card_media.html image=hero item=entry %}
                 <div class="card-body">
                   <h3 class="card-title">{{ entry.title }}</h3>
                   <p class="card-meta">
-                    <time>
-                      {% capture fmt %}
-                        {% if slug == 'events' and entry.starts_at %}
-                          %b %-d, %Y • %l:%M %P
-                        {% else %}
-                          %b %-d, %Y
-                        {% endif %}
-                      {% endcapture %}
-                      {% include date.html doc=entry format=fmt %}
-                    </time>
-                    {% if entry.location and slug == 'events' %} · {{ entry.location }}{% endif %}
+                    {% capture card_fmt -%}{% include resolve_date_format.html settings=card_settings doc=entry default=default_card_format %}{%- endcapture %}
+                    <time>{% include date.html doc=entry format=card_fmt %}</time>
+                    {% if card_settings.show_location and entry.location %} · {{ entry.location }}{% endif %}
                   </p>
                 </div>
               </a>
@@ -142,31 +125,19 @@ title: Home
       <li class="tl-item">
         <a class="card" href="{{ entry.url | relative_url }}">
           {% assign hero = entry.images | first %}
-          <div class="card-media">
-            {% if hero %}
-              {% assign _src = hero.src %}
-              {% assign first = _src | slice: 0, 1 %}
-              {% assign cleaned = _src | replace: './', '' %}
-              {% if _src contains '://' %}
-                {% assign resolved = _src %}
-              {% elsif first == '/' %}
-                {% assign resolved = _src %}
-              {% else %}
-                {% assign base = entry.path | replace: entry.name, '' %}
-                {% assign resolved = '/' | append: base | append: cleaned %}
-              {% endif %}
-              <img src="{{ resolved | relative_url }}" alt="{{ hero.alt | default: '' }}">
-            {% else %}
-              <img src="{{ '/assets/placeholders/placeholder_card_400x300.png' | relative_url }}" alt="">
-            {% endif %}
-          </div>
+          {% include card_media.html image=hero item=entry %}
           <div class="card-body">
             {% if sec_slug != '' %}
               <h6 class="card-section">{{ sec_label | upcase }}</h6>
             {% endif %}
             <h3 class="card-title">{{ entry.title }}</h3>
             <p class="card-meta">
-              <time>{% include date.html doc=entry format="%b %-d, %Y" %}</time>
+              {% assign entry_settings = nil %}
+              {% if sec_obj and sec_obj.entry %}
+                {% assign entry_settings = sec_obj.entry %}
+              {% endif %}
+              {% capture entry_fmt -%}{% include resolve_date_format.html settings=entry_settings doc=entry default=default_entry_format %}{%- endcapture %}
+              <time>{% include date.html doc=entry format=entry_fmt %}</time>
               {% if sec_slug != '' %} · {{ sec_label }}{% endif %}
             </p>
             {% if entry.summary %}<p class="card-summary">{{ entry.summary }}</p>{% endif %}


### PR DESCRIPTION
## Summary
- move section settings, placeholder paths, and default date formats into `_config.yml`
- add reusable includes for resolving media URLs, rendering card media, and computing section-aware date formats
- refactor `index.html` and entry layouts to use the new helpers so cards, timelines, and OG tags stay consistent as sections change

## Testing
- jekyll build *(fails: `jekyll` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c85ae1f1ac8333b26ab8cfa90fe680