### PR TITLE
Fix default layout OG image include syntax

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,8 +7,9 @@
 {%- assign base = site.baseurl | default: '' -%}
 
 {%- assign og_source = '' -%}
-{%- if page.images and page.images.size > 0 and page.images[0].src -%}
-  {%- capture og_candidate -%}{% include media_url.html src=page.images[0].src item=page %}{%- endcapture -%}
+{%- assign primary_image = page.images | first -%}
+{%- if primary_image and primary_image.src -%}
+  {%- capture og_candidate -%}{% include media_url.html src=primary_image.src item=page %}{%- endcapture -%}
   {%- assign og_source = og_candidate | strip -%}
 {%- endif -%}
 {%- if og_source == '' and site.logo -%}


### PR DESCRIPTION
## Summary
- ensure the default layout resolves the page's primary image before passing it to `media_url.html`
- avoid invalid Liquid include parameters by referencing the assigned image instead of an array index

## Testing
- bundle exec jekyll build *(fails: Could not locate Gemfile or .bundle/ directory)*
- jekyll build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8630890708333a07c1188e35bf5c8