### PR TITLE
Update header to reflect latest entry date

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -61,6 +61,7 @@ date_formats:
 
 exclude:
   - _local
+  - vendor
 
 logo: /assets/img/the_interurbanist_flag_1411x294.jpg
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,12 +3,24 @@
 <a href="{{ '/' | relative_url }}">
   <img src="{{ '/assets/img/shag-bicyclist-flag-1760x465.png' | relative_url }}" alt="The Interurbanist banner" class="brand-flag" width="700" height="150">
 </a>  
-	<div>
+  <div>
     <h1 class="site-title">The Interurbanist</h1>
-    {% assign tales = site.pages | where_exp:"p","p.dir contains '/tales/'"  %}
-    {% assign visions = site.pages | where_exp:"p","p.dir contains '/visions/'"  %}
-    {% assign all = tales | concat: visions | sort: 'path' | reverse %}
-    {% assign latest = all | first %}
+    {% assign entries = site.pages | where:"layout","entry" %}
+    {% assign latest = nil %}
+    {% assign latest_ts = 0 %}
+    {% for entry in entries %}
+      {% if entry.date %}
+        {% assign doc_ts = entry.date | date: '%s' | plus: 0 %}
+        {% if latest == nil or doc_ts > latest_ts %}
+          {% assign latest = entry %}
+          {% assign latest_ts = doc_ts %}
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+    {% if latest == nil %}
+      {% assign fallback = entries | sort: "path" | reverse %}
+      {% assign latest = fallback | first %}
+    {% endif %}
     <p class="site-desc">
       SHAG Interurban's Arts, Style, and Entertainment publication |
       Most recent post:


### PR DESCRIPTION
## Summary
- determine the newest entry across all sections to drive the header’s "Most recent post" message
- add a fallback to path ordering when no dated entries are available
- exclude the vendored bundle directory so Jekyll builds no longer scan gem templates

## Testing
- bundle exec jekyll -v
- bundle exec jekyll doctor || true
- JEKYLL_ENV=production bundle exec jekyll build --trace --strict_front_matter --baseurl "" -d _site-ci


------
https://chatgpt.com/codex/tasks/task_e_68c879f8512c833397bd9f04877d306c