### PR TITLE
Move text size controls to footer and enable article scaling

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,17 @@
 <footer class="site-footer mini" role="contentinfo" aria-label="Site footer">
   <hr class="footer-rule" aria-hidden="true">
 
+  <div class="text-size-controls">
+    <p class="text-size-text">
+      <span class="text-size-label" id="text-size-label">Text size</span>
+      <span class="text-size-instructions" id="text-size-desc">Use these buttons to make the reading text larger or smaller across the site.</span>
+    </p>
+    <div class="text-size-buttons" role="group" aria-labelledby="text-size-label" aria-describedby="text-size-desc">
+      <button class="text-size-btn fs-inc" type="button" aria-label="Increase text size">A+</button>
+      <button class="text-size-btn fs-dec" type="button" aria-label="Decrease text size">A−</button>
+    </div>
+  </div>
+
   <!-- one-line nav, 9px -->
   <p class="footer-links">
     <a href="{{ '/about/' | relative_url }}">About</a> ·

--- a/_includes/tabs.html
+++ b/_includes/tabs.html
@@ -1,10 +1,8 @@
-<nav class="tabbar" aria-label="Site view and text size">
+<nav class="tabbar" aria-label="Site view">
   <div class="tabs">
     <a class="tab btn mode-toggle" data-mode="timeline"
        href="{{ '/' | relative_url }}?view=timeline">⏲️ Timeline</a>
     <a class="tab btn mode-toggle" data-mode="sections"
        href="{{ '/' | relative_url }}?view=sections">📁 Sections</a>
-    <button class="tab btn fs-dec" type="button" aria-label="Decrease text size">A−</button>
-    <button class="tab btn fs-inc" type="button" aria-label="Increase text size">A+</button>
   </div>
 </nav>

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -20,7 +20,7 @@
   --btn-hover-bg:#e9f3f2;
   --btn-active-bg:#d9eceb;
 
-  --size:18px;
+  --size:1.125rem;
   --radius:16px;
   --border:3px;
 }
@@ -241,12 +241,49 @@ html.mode-sections .tabbar .tab[data-mode="sections"]{
 /* if the first thing in main is adding extra space, zero it */
 main > *:first-child{ margin-top: 0; }
 
-/* Super-compact footer that ignores A−/A+ (point-locked sizes allowed by you) */
+/* Super-compact footer */
 .site-footer{
   margin-top:8px;padding:6px 0 10px;font-size:0;color:var(--muted);
 }
 .footer-rule{
   border:0;height:1px;background:var(--line);margin:0 0 6px;
+}
+/* text size controls */
+.text-size-controls{
+  margin:1rem auto 1.25rem;
+  padding:0 1rem;
+  max-width:min(640px, 90vw);
+  display:flex;flex-direction:column;gap:0.65rem;align-items:center;
+  font-size:1rem;color:var(--fg);
+}
+.text-size-text{
+  margin:0;text-align:center;line-height:1.4;
+}
+.text-size-label{
+  display:block;font-weight:700;text-transform:uppercase;letter-spacing:.08em;
+}
+.text-size-instructions{
+  display:block;margin-top:0.2rem;color:var(--muted);font-size:0.95rem;
+}
+.text-size-buttons{
+  display:flex;gap:0.9rem;align-items:center;justify-content:center;
+}
+.text-size-btn{
+  min-width:3rem;min-height:3rem;
+  padding:0.5rem;
+  border:3px solid #000;border-radius:999px;
+  background:#bdf0b4;color:#000;font-weight:700;font-size:1.2rem;
+  line-height:1;cursor:pointer;box-shadow:0 2px 0 rgba(0,0,0,0.25);
+  transition:transform .15s ease, box-shadow .15s ease, background-color .15s ease;
+}
+.text-size-btn:hover{
+  background:#a9e69e;box-shadow:0 3px 0 rgba(0,0,0,0.3);
+}
+.text-size-btn:active{
+  transform:translateY(1px);box-shadow:0 1px 0 rgba(0,0,0,0.2);
+}
+.text-size-btn:focus-visible{
+  outline:3px solid var(--accent-strong);outline-offset:3px;
 }
 /* one-line nav (≈9pt) */
 .footer-links{


### PR DESCRIPTION
## Summary
- relocate the text size controls from the header tabs into the footer with clearer instructions
- restyle the buttons to be large, round controls with a light green fill and strong border for touch targets
- switch the body font size to rem-based scaling so article pages respond to the text size adjustments

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68cb1f2b2c808333a6f67509b21b1cd5